### PR TITLE
Fix permissions for com.palm.wifi

### DIFF
--- a/files/sysbus/webos-connman-adapter.api.json
+++ b/files/sysbus/webos-connman-adapter.api.json
@@ -39,7 +39,7 @@
         "com.palm.wifi/setstate",
         "com.palm.wifi/startwps"
     ],
-    "networking": [
+    "public": [
         "com.palm.connectionmanager/checkinternetstatus",
         "com.palm.connectionmanager/findProxyForURL",
         "com.palm.connectionmanager/getinfo",

--- a/files/sysbus/webos-connman-adapter.perm.json
+++ b/files/sysbus/webos-connman-adapter.perm.json
@@ -2,7 +2,8 @@
     "com.palm.wifi": [
         "settings",
         "devices",
-        "networking.internal"
+        "networking.internal", 
+        "public"
     ],
     "com.palm.connectionmanager": [
         "settings",


### PR DESCRIPTION
Reuse the "public" compat group

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>